### PR TITLE
Aktualisiere JS hook nach DOM Umbau (Case 129082)

### DIFF
--- a/js/targeting.js
+++ b/js/targeting.js
@@ -15,6 +15,8 @@ $(function() {
                     if (link.triggerHandler('click') !== false)
                         window.location.href = link.attr('href');
             });
+            targetingZone.removeClass('targeting');
+            targetingZone.addClass('targetted');
         } else {
             targetingZone.attr('class', targetingZone.attr('class').replace(/targeting[-\w]*/g, ''));
         }


### PR DESCRIPTION
Zurzeit binden wir in einzelnen µ-Services sowohl im konkattenierten JS des Services selbst, als auch über das JS des Monolithen die targeting.js ein. Das führt zu doppelter Ausführung und im Browser zu duplizierten Texten.

Dieser "fix" ist ein Pflaster, das die unnötige doppelte Einbindung des Skriptes nicht löst, aber zumindest die doppelte Aussführung vermeidet.